### PR TITLE
Replace hydrate function with render to avoid css dropping bug in gastby/react

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -2,3 +2,12 @@
 import "typeface-source-sans-pro"
 
 import "prismjs/themes/prism.css"
+
+// replace hydrate function with straight render to fix https://github.com/gatsbyjs/gatsby/issues/8560. Does affect performance
+const ReactDOM = require("react-dom")
+
+export function replaceHydrateFunction() {
+  return (element, container, callback) => {
+    ReactDOM.render(element, container, callback)
+  }
+}


### PR DESCRIPTION
This is a weird bug, see https://github.com/gatsbyjs/gatsby/issues/17914 if you're curious. But it can sometimes result in the css getting dropped, so we replace the buggy function with a straight render to get around it. It's less performant but still great for use use cases.