### PR TITLE
Fix footer mobile view

### DIFF
--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -140,15 +140,17 @@ a {
 }
 
 .footer-buttons .linked-button {
-  margin: 15px;
+  margin-top: 15px;
+  margin-left: 15px;
 }
 
 .footer-social {
   display: flex;
   align-content: flex-end;
   flex-direction: row;
-  justify-content: space-between;
-  margin: 15px;
+  justify-content: space-evenly;
+  margin: 10px;
+  flex-wrap: wrap;
 }
 
 .footer-social-button {
@@ -162,7 +164,7 @@ a {
   text-decoration: none;
   color: var(--sunrise-dark);
   text-align: center;
-  margin-left: 10px;
+  margin: 10px;
   padding: 10px;
   font-size: 2em;
 }

--- a/src/util.js
+++ b/src/util.js
@@ -7,5 +7,5 @@ export function getScreenWidth() {
 }
 
 export function isNarrowWidth() {
-  return getScreenWidth() < 600
+  return getScreenWidth() < 800
 }


### PR DESCRIPTION
Missed this in the last PR for mobile views. Now footer doesn't overflow.

Also, just setting mobile to less than 800 instead of 600 since it just is easier to manage